### PR TITLE
fix: check workers status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ hyper-util = { version = "0.1", features = ["full"] }
 http-body-util = "0.1"
 lazy_static = "1.4.0"
 regex = "1"
+reqwest = "0.12"
 sqlx = { version = "0.8", features = ["postgres", "sqlite", "runtime-tokio-rustls", "chrono"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::Report;
+use datafusion::arrow::error::ArrowError;
 use datafusion::error::DataFusionError;
 use thiserror::Error;
 use hyper::http::Error as HttpError;
@@ -6,6 +7,7 @@ use hyper::http::uri::InvalidUri;
 use hyper::Error as HyperError;
 use std::io::Error as IoError;
 use regex::Error as RegexError;
+use reqwest::Error as ReqwestError;
 
 #[derive(Debug, Error)]
 pub enum LoadBalancerError {
@@ -24,6 +26,9 @@ pub enum LoadBalancerError {
     #[error("Invalid uri")]
     InvalidUri(#[from] InvalidUri),
 
+    #[error("ArrowError")]
+    ArrowError(#[from] ArrowError),
+
     #[error("DataFusionError")]
     DataFusionError(#[from] DataFusionError),
 
@@ -38,6 +43,9 @@ pub enum LoadBalancerError {
 
     #[error("Regex error")]
     RegexError(#[from] RegexError),
+
+    #[error("Reqwest error")]
+    ReqwestError(#[from] ReqwestError),
     
     #[error("Unexpected error")]
     UnexpectedError(#[source] Report),

--- a/src/load_balancer.rs
+++ b/src/load_balancer.rs
@@ -1,6 +1,9 @@
 use std::str::FromStr;
+use std::sync::Arc;
 
 use color_eyre::eyre::{Context, ContextCompat};
+use datafusion::arrow::array::{BooleanArray, Int64Array, RecordBatch};
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::prelude::*;
 use http_body_util::BodyExt;
 use hyper::{
@@ -11,7 +14,7 @@ use hyper_util::rt::TokioIo;
 use tokio::net::TcpStream;
 
 use crate::data_store::Worker;
-use crate::utils::{df_to_table, validate_address, DF_TABLE_NAME};
+use crate::utils::{df_to_table, validate_address, DF_TABLE_NAME, HEALTH_ROUTE};
 use crate::BoxBody;
 use crate::error::LoadBalancerError;
 
@@ -42,8 +45,17 @@ impl LoadBalancer {
         self.algorithm = algorithm
     }
 
+    pub async fn show_table(&self) -> Result<(), LoadBalancerError> {
+        let df = self.ctx.sql(&format!("select * from {DF_TABLE_NAME} order by id")).await?;
+        df.show().await?;
+        Ok(())
+    }
+}
+
+impl LoadBalancer {
     pub async fn forward_request(&mut self, req: Request<Incoming>) -> Result<Response<BoxBody>, LoadBalancerError> {
-        let mut worker_uri = self.get_worker().await?;
+        self.check_workers_health().await?; // check all workers and setup status #TODO move it into init stage
+        let mut worker_uri = self.get_worker().await?; // get active worker
 
         if let Some(path_and_query) = req.uri().path_and_query() {
             worker_uri.push_str(path_and_query.as_str());
@@ -88,6 +100,72 @@ impl LoadBalancer {
         Ok(Response::new(res_body))
     }
 
+    /// Check all workers and setup 'status'
+    async fn check_workers_health(&self) -> Result<(), LoadBalancerError> {
+        println!("checking worker servers health");
+        let workers_df = self.ctx
+            .sql(&format!("select id, worker_name, port_name, count_cons from {DF_TABLE_NAME}"))
+            .await?;
+        let workers = Worker::to_records(workers_df.clone())
+            .await
+            .map_err(|e| LoadBalancerError::UnexpectedError(e.into()))?;
+
+        let mut tasks = vec![];
+        for worker in workers {
+            let worker_id = worker.id
+                .wrap_err("worker port is empty")
+                .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
+            let worker_name = worker.name.clone()
+                .wrap_err("worker name is empty")
+                .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
+            let worker_port = worker.port.clone()
+                .wrap_err("worker port is empty")
+                .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
+            let worker_url = format!("http://{}:{}", worker_name, worker_port);
+            if !validate_address(&worker_url)? {
+                return Err(LoadBalancerError::InvalidWorkerHostAddress);
+            }
+            let worker_url_health = format!("{worker_url}{HEALTH_ROUTE}");
+            let task = tokio::spawn(check_health(worker_id, worker_url_health));
+            tasks.push(task);
+        }
+
+        let mut ids = vec![];
+        let mut statuses = vec![];
+        for task in tasks {
+            match task.await {
+                Ok(res) => {
+                    ids.push(res.0);
+                    statuses.push(res.1);
+                },
+                Err(e) => eprintln!("Failed running worker activity status: {e}")
+            };
+        }
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("status", DataType::Boolean, true),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(Int64Array::from(ids)),
+                Arc::new(BooleanArray::from(statuses)),
+            ],
+        )?;
+        let workers_status = self.ctx
+            .read_batch(batch)?
+            .with_column_renamed("id", "id2")?;
+
+        let active_workers = workers_df
+            .join(workers_status, JoinType::Inner, &["id"], &["id2"], None)?
+            .drop_columns(&["id2"])?;
+        self.ctx.deregister_table(format!("{DF_TABLE_NAME}"))?;
+        df_to_table(self.ctx.clone(), active_workers, DF_TABLE_NAME).await?;
+
+        Ok(())
+    }
+
+    /// Get active worker 
     async fn get_worker(&mut self) -> Result<String, LoadBalancerError> {
         match self.algorithm {
             Algorithm::RoundRobin => {
@@ -96,72 +174,154 @@ impl LoadBalancer {
                 let df = self.ctx
                     .sql(&format!("select id, worker_name, port_name, count_cons 
                                  from {DF_TABLE_NAME} 
-                                 where id = {round_robin_sql}"))
+                                 where 1 = 1 
+                                 and status is true
+                                 and id = {round_robin_sql}"))
                     .await
                     .map_err(|e| LoadBalancerError::UnexpectedError(e.into()))?;
+
                 let workers = Worker::to_records(df)
                     .await
                     .map_err(|e| LoadBalancerError::UnexpectedError(e.into()))?;
-                let worker = workers.get(0)
-                    .wrap_err("workers is empty")
-                    .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
-                let worker_name = worker.name.clone()
-                    .wrap_err("worker name is empty")
-                    .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
-                let worker_port = worker.port.clone()
-                    .wrap_err("worker port is empty")
-                    .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
-                let worker_url = format!("http://{}:{}", worker_name, worker_port);
-                if !validate_address(&worker_url)? {
-                    return Err(LoadBalancerError::InvalidWorkerHostAddress);
+
+                if workers.is_empty() {
+                    return Err(LoadBalancerError::EmptyWorkerHostAddress);
                 }
-                self.current_worker += 1;
-        
-                Ok(worker_url)
+
+                // check each worker if alive
+                let mut idx = 0usize;
+                let res = loop {
+                    let worker = workers.get(idx)
+                        .wrap_err("workers are empty")
+                        .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
+
+                    let worker_name = worker.name.clone()
+                        .wrap_err("worker name is empty")
+                        .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
+
+                    let worker_port = worker.port.clone()
+                        .wrap_err("worker port is empty")
+                        .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
+
+                    let worker_url = format!("http://{}:{}", worker_name, worker_port);
+                    if !validate_address(&worker_url)? {
+                        return Err(LoadBalancerError::InvalidWorkerHostAddress);
+                    }
+
+                    let worker_url_health = format!("{worker_url}{HEALTH_ROUTE}");
+                    if alive(worker_url_health).await {
+                        self.current_worker += 1;
+                        break worker_url;
+                    }
+
+                    idx += 1;
+                };
+
+                Ok(res)
             },
+
             Algorithm::LeastConnections => {
                 let sql = format!("select id, worker_name, port_name, count_cons
                                             from {DF_TABLE_NAME} 
-                                            where count_cons = (select min(count_cons) from {DF_TABLE_NAME})");
+                                            where 1 = 1 
+                                            and status is true
+                                            and count_cons = (select min(count_cons) from {DF_TABLE_NAME})");
                 let df = self.ctx
                     .sql(&sql)
                     .await
                     .map_err(|e| LoadBalancerError::UnexpectedError(e.into()))?;
+
                 let workers = Worker::to_records(df)
                     .await
                     .wrap_err("error when parsing to records")
                     .map_err(|e| LoadBalancerError::UnexpectedError(e.into()))?;
-                let worker = workers.get(0)
-                    .wrap_err("workers is empty")
-                    .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
-                let worker_name = worker.name.clone()
-                    .wrap_err("worker name is empty")
-                    .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
-                let worker_port = worker.port.clone()
-                    .wrap_err("worker port is empty")
-                    .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
-                let worker_id = worker.id
-                    .wrap_err("worker port is empty")
-                    .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
-                let worker_url = format!("http://{}:{}", worker_name, worker_port);
-                if !validate_address(&worker_url)? {
-                    return Err(LoadBalancerError::InvalidWorkerHostAddress);
+
+                if workers.is_empty() {
+                    return Err(LoadBalancerError::EmptyWorkerHostAddress);
                 }
 
-                // updating count_cons column and register new table 
-                let sql = format!("select id, worker_name, port_name, 
-                                            case
-                                                when id = {worker_id} then count_cons + 1
-                                                else count_cons
-                                            end as count_cons
-                                            from {DF_TABLE_NAME}");
-                let df = self.ctx.sql(&sql).await?;
-                self.ctx.deregister_table(format!("{DF_TABLE_NAME}"))?;
-                df_to_table(self.ctx.clone(), df, DF_TABLE_NAME).await?;
-                // self.ctx.sql(&format!("select * from {DF_TABLE_NAME}")).await?.show().await?; // debug updated col count_cons
+                // check each worker if alive
+                let mut idx = 0usize;
+                let res = loop {
+                    let worker = workers.get(idx)
+                        .wrap_err("workers is empty")
+                        .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
 
-                Ok(worker_url)
+                    let worker_name = worker.name.clone()
+                        .wrap_err("worker name is empty")
+                        .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
+
+                    let worker_port = worker.port.clone()
+                        .wrap_err("worker port is empty")
+                        .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
+
+                    let worker_id = worker.id
+                        .wrap_err("worker port is empty")
+                        .map_err(|e| LoadBalancerError::UnexpectedError(e))?;
+
+                    let worker_url = format!("http://{}:{}", worker_name, worker_port);
+                    if !validate_address(&worker_url)? {
+                        return Err(LoadBalancerError::InvalidWorkerHostAddress);
+                    }
+
+                    let worker_url_health = format!("{worker_url}{HEALTH_ROUTE}");
+                    if alive(worker_url_health).await {
+                        // updating count_cons column and register new table 
+                        let sql = format!("select id, worker_name, port_name, 
+                                                    case
+                                                        when id = {worker_id} then count_cons + 1
+                                                        else count_cons
+                                                    end as count_cons
+                                                    from {DF_TABLE_NAME}");
+                        let df = self.ctx.sql(&sql).await?;
+                        self.ctx.deregister_table(format!("{DF_TABLE_NAME}"))?;
+                        df_to_table(self.ctx.clone(), df, DF_TABLE_NAME).await?;
+                        break worker_url;
+                    }
+
+                    idx += 1;
+                };
+
+                Ok(res)   
             }
         }
     }
+}
+
+pub async fn alive(url: String) -> bool {
+    let client = reqwest::Client::new();
+
+    client.get(url)
+        .send()
+        .await
+        .ok()
+        .map(|response| {
+            let res = match response.status().as_u16() {
+                200 => true,
+                _ => false
+            };
+            Some(res)
+        })
+        .flatten()
+        .unwrap_or(false)
+}
+
+pub async fn check_health(id: i64, url: String) -> (i64, bool) {
+    let client = reqwest::Client::new();
+
+    let status = client.get(url)
+        .send()
+        .await
+        .ok()
+        .map(|response| {
+            let res = match response.status().as_u16() {
+                200 => true,
+                _ => false
+            };
+            Some(res)
+        })
+        .flatten()
+        .unwrap_or(false);
+
+    (id, status)
 }

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -7,6 +7,7 @@ pub const LOAD_BALANCER_NAME: &str = "ultra";
 pub const MAX_DB_CONS: u32 = 100;
 pub const TABLE_NAME: &str = "workers"; // postgres/sqlite table name
 pub const DF_TABLE_NAME: &str = "workers"; // datafusion table name
+pub const HEALTH_ROUTE: &str = "/alive";
 
 pub mod env {
     pub const PG_DATABASE_URL_ENV_VAR: &str = "PG_DATABASE_URL";


### PR DESCRIPTION
Keep track of workers status. Before forwarding request, check if worker is alive (using health route).